### PR TITLE
fivem has a string limit, use blips like bdub wants

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -26,20 +26,6 @@ local EntitySliceInfinite = {
         _EndTextCommandDisplayHelp(0, true, beep, -1)
     end
 
-    CreateBlip = function(name, coords, sprite, colour, scale)
-        local blip = AddBlipForCoord(coords)
-
-        SetBlipSprite (blip, sprite)
-        SetBlipScale  (blip, scale or 1.0)
-        SetBlipColour (blip, colour)
-        SetBlipAsShortRange(blip, true)
-
-		AddTextEntry(name, name)
-		BeginTextCommandSetBlipName(name)
-		EndTextCommandSetBlipName(blip)
-        return blip
-    end
-
     -- Markers
         DrawMarkerType = function(type, v)
             if type == 0 then

--- a/client/main.lua
+++ b/client/main.lua
@@ -34,9 +34,9 @@ local EntitySliceInfinite = {
         SetBlipColour (blip, colour)
         SetBlipAsShortRange(blip, true)
 
-        BeginTextCommandSetBlipName('STRING')
-        AddTextComponentSubstringPlayerName(name)
-        EndTextCommandSetBlipName(blip)
+		AddTextEntry(name, name)
+		BeginTextCommandSetBlipName(name)
+		EndTextCommandSetBlipName(blip)
         return blip
     end
 

--- a/client/native.lua
+++ b/client/native.lua
@@ -968,9 +968,9 @@ end
         SetBlipColour (blip, colour)
         SetBlipAsShortRange(blip, true)
 
-		AddTextEntry(name, name)
-		BeginTextCommandSetBlipName(name)
-		EndTextCommandSetBlipName(blip)
+        AddTextEntry(name, name)
+        BeginTextCommandSetBlipName(name)
+        EndTextCommandSetBlipName(blip)
         return blip
     end
 

--- a/client/native.lua
+++ b/client/native.lua
@@ -968,9 +968,9 @@ end
         SetBlipColour (blip, colour)
         SetBlipAsShortRange(blip, true)
 
-        BeginTextCommandSetBlipName('STRING')
-        _AddTextComponentSubstringPlayerName(name)
-        EndTextCommandSetBlipName(blip)
+		AddTextEntry(name, name)
+		BeginTextCommandSetBlipName(name)
+		EndTextCommandSetBlipName(blip)
         return blip
     end
 


### PR DESCRIPTION
fivem has a string limit, use blips like bdub wants

https://docs.fivem.net/natives/?_0x32CA01C3

https://docs.fivem.net/natives/?_0xF9113A30DE5C6670


Ive tested this in multiple scripts and it works, not 100% on all ways the lib may be used but everything I have that uses it is working. 

I saw a conversation bdub had in the fivem discord saying there is no blip limit but there is a string limit and strings are the lazy way of using these natives