### PR TITLE
use oxmysql instead of mysql-async

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -13,7 +13,7 @@ client_scripts {
 }
 
 server_scripts {
-    "@mysql-async/lib/MySQL.lua",
+    "@oxmysql/lib/MySQL.lua",
     
     "config.lua",
     "server/native.lua",


### PR DESCRIPTION
Using [oxmysql](https://github.com/overextended/oxmysql/) instead of the deprecated mysql-async